### PR TITLE
Setup `react-hook-form` in Edit Contributions

### DIFF
--- a/src/components/issues/InputFormControl.tsx
+++ b/src/components/issues/InputFormControl.tsx
@@ -17,6 +17,7 @@ export default function InputFormControl({
 	id,
 	info,
 	placeholder = '',
+	...defaultProps
 }: FunctionProps) {
 	const tooltipId = `${label}-${id}`;
 
@@ -47,7 +48,7 @@ export default function InputFormControl({
 				placeholder={placeholder}
 				className="mt-0.5 w-lg py-2 placeholder:text-sm max-md:w-full"
 				id={id}
-				required={required}
+				{...defaultProps}
 			/>
 		</div>
 	);

--- a/src/components/issues/TextAreaFormControl.tsx
+++ b/src/components/issues/TextAreaFormControl.tsx
@@ -17,6 +17,7 @@ export default function TextAreaFormControl({
 	id,
 	info,
 	placeholder = '',
+	...defaultProps
 }: FunctionProps) {
 	const tooltipId = `${label}-${id}`;
 
@@ -47,6 +48,7 @@ export default function TextAreaFormControl({
 				placeholder={placeholder}
 				className="mt-0.5 w-lg py-2 placeholder:text-sm max-md:w-full"
 				id={id}
+				{...defaultProps}
 			/>
 		</div>
 	);

--- a/src/components/views/FormErrorLabel.tsx
+++ b/src/components/views/FormErrorLabel.tsx
@@ -1,0 +1,16 @@
+import { ShieldAlert } from 'lucide-react';
+
+interface FunctionProps {
+	children: Readonly<React.ReactNode>;
+}
+
+export default function FormErrorLabel({ children }: FunctionProps) {
+	return (
+		<label className="text-primary-40 flex items-center justify-start gap-x-1 text-sm">
+			<span>
+				<ShieldAlert size={14} />
+			</span>
+			<span>{children}</span>
+		</label>
+	);
+}

--- a/src/data/issues/editDynastyFields.ts
+++ b/src/data/issues/editDynastyFields.ts
@@ -1,6 +1,16 @@
 import { IssuesFormControlOptions } from '@/interfaces/IssuesFormControlOptions';
 
-const editDynastyFields: IssuesFormControlOptions[] = [
+type EditDynastyOptions = IssuesFormControlOptions & {
+	registerHookForm:
+		| 'name'
+		| 'link'
+		| 'fieldName'
+		| 'fieldContent'
+		| 'sources'
+		| 'comments';
+};
+
+const editDynastyFields: EditDynastyOptions[] = [
 	{
 		id: 1,
 		required: true,
@@ -8,6 +18,7 @@ const editDynastyFields: IssuesFormControlOptions[] = [
 		placeholder: 'Name of the dynasty you wish to edit',
 		type: 'input',
 		htmlId: 'edit-dynasty-name',
+		registerHookForm: 'name',
 	},
 	{
 		id: 2,
@@ -17,6 +28,7 @@ const editDynastyFields: IssuesFormControlOptions[] = [
 		type: 'input',
 		htmlId: 'edit-dynasty-link',
 		info: `Please make sure the provided link is not broken and correct; you can get the dynasty page link using the 'Copy URL' button on its page`,
+		registerHookForm: 'link',
 	},
 	{
 		id: 3,
@@ -27,6 +39,7 @@ const editDynastyFields: IssuesFormControlOptions[] = [
 		type: 'input',
 		htmlId: 'edit-dynasty-field-name',
 		info: 'Only provide the name of the field that currently holds an empty value or has incorrect content',
+		registerHookForm: 'fieldName',
 	},
 	{
 		id: 4,
@@ -36,6 +49,7 @@ const editDynastyFields: IssuesFormControlOptions[] = [
 		type: 'textarea',
 		htmlId: 'edit-dynasty-field-content',
 		info: 'Provide the appropriate value (answer) for the previously mentioned field that holds incorrect or missing content',
+		registerHookForm: 'fieldContent',
 	},
 	{
 		id: 5,
@@ -45,6 +59,7 @@ const editDynastyFields: IssuesFormControlOptions[] = [
 		type: 'textarea',
 		htmlId: 'edit-dynasty-sources',
 		info: 'Include links to one or more sources that proves credibility about your response/answer to be factually correct',
+		registerHookForm: 'sources',
 	},
 	{
 		id: 6,
@@ -55,6 +70,7 @@ const editDynastyFields: IssuesFormControlOptions[] = [
 		placeholder:
 			'Include any additional comments that is closely relevant to this entity',
 		info: 'You can mention any new ideas and suggestions or provide any comments or context here',
+		registerHookForm: 'comments',
 	},
 ];
 

--- a/src/data/issues/editRulerFields.ts
+++ b/src/data/issues/editRulerFields.ts
@@ -1,6 +1,16 @@
 import { IssuesFormControlOptions } from '@/interfaces/IssuesFormControlOptions';
 
-const editRulerFields: IssuesFormControlOptions[] = [
+type EditRulerOptions = IssuesFormControlOptions & {
+	registerHookForm:
+		| 'name'
+		| 'link'
+		| 'fieldName'
+		| 'fieldContent'
+		| 'sources'
+		| 'comments';
+};
+
+const editRulerFields: EditRulerOptions[] = [
 	{
 		id: 1,
 		required: true,
@@ -8,6 +18,7 @@ const editRulerFields: IssuesFormControlOptions[] = [
 		placeholder: 'Name of the ruler you wish to edit',
 		type: 'input',
 		htmlId: 'edit-ruler-name',
+		registerHookForm: 'name',
 	},
 	{
 		id: 2,
@@ -17,6 +28,7 @@ const editRulerFields: IssuesFormControlOptions[] = [
 		type: 'input',
 		htmlId: 'edit-ruler-link',
 		info: `Please make sure the provided link is not broken and correct; you can get the ruler page link using the 'Copy URL' button on its page`,
+		registerHookForm: 'link',
 	},
 	{
 		id: 3,
@@ -27,6 +39,7 @@ const editRulerFields: IssuesFormControlOptions[] = [
 		type: 'input',
 		htmlId: 'edit-ruler-field-name',
 		info: 'Only provide the name of the field that currently holds an empty value or has incorrect content',
+		registerHookForm: 'fieldName',
 	},
 	{
 		id: 4,
@@ -36,6 +49,7 @@ const editRulerFields: IssuesFormControlOptions[] = [
 		type: 'textarea',
 		htmlId: 'edit-ruler-field-content',
 		info: 'Provide the appropriate value (answer) for the previously mentioned field that holds incorrect or missing content',
+		registerHookForm: 'fieldContent',
 	},
 	{
 		id: 5,
@@ -45,6 +59,7 @@ const editRulerFields: IssuesFormControlOptions[] = [
 		type: 'textarea',
 		htmlId: 'edit-ruler-sources',
 		info: 'Include links to one or more sources that proves credibility about your response/answer to be factually correct',
+		registerHookForm: 'sources',
 	},
 	{
 		id: 6,
@@ -55,6 +70,7 @@ const editRulerFields: IssuesFormControlOptions[] = [
 		placeholder:
 			'Include any additional comments that is closely relevant to this entity',
 		info: 'You can mention any new ideas and suggestions or provide any comments or context here',
+		registerHookForm: 'comments',
 	},
 ];
 

--- a/src/data/issues/editWarFields.ts
+++ b/src/data/issues/editWarFields.ts
@@ -1,6 +1,16 @@
 import { IssuesFormControlOptions } from '@/interfaces/IssuesFormControlOptions';
 
-const editWarFields: IssuesFormControlOptions[] = [
+type EditWarOptions = IssuesFormControlOptions & {
+	registerHookForm:
+		| 'name'
+		| 'link'
+		| 'fieldName'
+		| 'fieldContent'
+		| 'sources'
+		| 'comments';
+};
+
+const editWarFields: EditWarOptions[] = [
 	{
 		id: 1,
 		required: true,
@@ -8,6 +18,7 @@ const editWarFields: IssuesFormControlOptions[] = [
 		placeholder: 'Name of the war you wish to edit',
 		type: 'input',
 		htmlId: 'edit-war-name',
+		registerHookForm: 'name',
 	},
 	{
 		id: 2,
@@ -17,6 +28,7 @@ const editWarFields: IssuesFormControlOptions[] = [
 		type: 'input',
 		htmlId: 'edit-war-link',
 		info: `Please make sure the provided link is not broken and correct; you can get the war page link using the 'Copy URL' button on its page`,
+		registerHookForm: 'link',
 	},
 	{
 		id: 3,
@@ -27,6 +39,7 @@ const editWarFields: IssuesFormControlOptions[] = [
 		type: 'input',
 		htmlId: 'edit-war-field-name',
 		info: 'Only provide the name of the field that currently holds an empty value or has incorrect content',
+		registerHookForm: 'fieldName',
 	},
 	{
 		id: 4,
@@ -36,6 +49,7 @@ const editWarFields: IssuesFormControlOptions[] = [
 		type: 'textarea',
 		htmlId: 'edit-war-field-content',
 		info: 'Provide the appropriate value (answer) for the previously mentioned field that holds incorrect or missing content',
+		registerHookForm: 'fieldContent',
 	},
 	{
 		id: 5,
@@ -45,6 +59,7 @@ const editWarFields: IssuesFormControlOptions[] = [
 		type: 'textarea',
 		htmlId: 'edit-war-sources',
 		info: 'Include links to one or more sources that proves credibility about your response/answer to be factually correct',
+		registerHookForm: 'sources',
 	},
 	{
 		id: 6,
@@ -55,6 +70,7 @@ const editWarFields: IssuesFormControlOptions[] = [
 		placeholder:
 			'Include any additional comments that is closely relevant to this entity',
 		info: 'You can mention any new ideas and suggestions or provide any comments or context here',
+		registerHookForm: 'comments',
 	},
 ];
 

--- a/src/data/issues/userInfo.ts
+++ b/src/data/issues/userInfo.ts
@@ -1,6 +1,11 @@
 import { IssuesFormControlOptions } from '@/interfaces/IssuesFormControlOptions';
 
-const userInfo: IssuesFormControlOptions[] = [
+type UserInfoOptions = IssuesFormControlOptions & {
+	registerHookForm: 'userFullName' | 'userLocation' | 'userEmail';
+	validationPattern?: string | RegExp;
+};
+
+const userInfo: UserInfoOptions[] = [
 	{
 		id: 1,
 		htmlId: 'user-info-name',
@@ -8,6 +13,7 @@ const userInfo: IssuesFormControlOptions[] = [
 		label: 'Full Name',
 		required: true,
 		placeholder: 'John Doe',
+		registerHookForm: 'userFullName',
 	},
 	{
 		id: 2,
@@ -16,6 +22,8 @@ const userInfo: IssuesFormControlOptions[] = [
 		label: 'Email',
 		required: true,
 		placeholder: 'john.doe@example.com',
+		registerHookForm: 'userEmail',
+		validationPattern: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
 	},
 	{
 		id: 3,
@@ -25,6 +33,7 @@ const userInfo: IssuesFormControlOptions[] = [
 		required: false,
 		placeholder: 'Your city and/or country (Optional)',
 		info: 'You can include your city and/or country. This is an optional field and we ask this for demographic analytics purpose',
+		registerHookForm: 'userLocation',
 	},
 ];
 

--- a/src/interfaces/EditFormInputs.ts
+++ b/src/interfaces/EditFormInputs.ts
@@ -1,0 +1,15 @@
+interface EditFormInputs {
+	name: string;
+	link: string;
+	fieldName: string;
+	fieldContent: string;
+	sources: string;
+	comments: string;
+
+	// User Info
+	userFullName: string;
+	userLocation: string;
+	userEmail: string;
+}
+
+export type { EditFormInputs };

--- a/src/interfaces/IssuesFormControlOptions.ts
+++ b/src/interfaces/IssuesFormControlOptions.ts
@@ -6,6 +6,7 @@ interface IssuesFormControlOptions {
 	type: 'input' | 'textarea' | 'select';
 	htmlId?: string;
 	info?: string;
+	registerHookForm?: string;
 }
 
 export type { IssuesFormControlOptions };

--- a/src/sections/AddNewContribution.tsx
+++ b/src/sections/AddNewContribution.tsx
@@ -3,7 +3,6 @@ import NewEntityTabsContent from './issues/new/NewEntityTabsContent';
 import NewDynastyTabsContent from './issues/new/NewDynastyTabsContent';
 import NewRulerTabsContent from './issues/new/NewRulerTabsContent';
 import NewWarTabsContent from './issues/new/NewWarTabsContent';
-import UserInfo from './issues/user/UserInfo';
 import BasicButton from '@/components/elements/BasicButton';
 import { Send } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -15,7 +14,6 @@ export default function AddNewContribution() {
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	const tabType = searchParams.get('type') || DEFAULT_NEW_CONTRIBUTION_TAB;
-	console.log(tabType);
 	const [tabValue, setTabValue] = useState<string>(tabType);
 
 	function changeTab(e: string) {
@@ -61,7 +59,7 @@ export default function AddNewContribution() {
 						<NewWarTabsContent />
 					</div>
 				</Tabs>
-				<UserInfo />
+				{/* <UserInfo /> */}
 
 				<BasicButton
 					variant="light"

--- a/src/sections/EditContribution.tsx
+++ b/src/sections/EditContribution.tsx
@@ -1,12 +1,14 @@
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import UserInfo from './issues/user/UserInfo';
 import BasicButton from '@/components/elements/BasicButton';
 import { Send } from 'lucide-react';
 import EditDynastyTabsContent from './issues/edit/EditDynastyTabsContent';
-import EditRulerTabsContent from './issues/edit/EditRulerTabsContent';
 import EditWarTabsContent from './issues/edit/EditWarTabsContent';
 import { useSearchParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { FormEventHandler, useEffect, useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import EditRulerTabsContent from './issues/edit/EditRulerTabsContent';
+import UserInfo from './issues/user/UserInfo';
+import { EditFormInputs } from '@/interfaces/EditFormInputs';
 
 const DEFAULT_EDIT_CONTRIBUTION_TAB = 'dynasty';
 
@@ -38,37 +40,135 @@ export default function EditContribution() {
 		[tabValue]
 	);
 
+	// Dedicated useForm clients for each tab
+	// Edit Dynasty useForm
+	const {
+		register: dynastyRegister,
+		handleSubmit: dynastyHandleSubmit,
+		formState: { errors: dynastyErrors },
+	} = useForm<EditFormInputs>();
+
+	// Edit Ruler useForm
+	const {
+		register: rulerRegister,
+		handleSubmit: rulerHandleSubmit,
+		formState: { errors: rulerErrors },
+	} = useForm<EditFormInputs>();
+
+	// Edit War useForm
+	const {
+		register: warRegister,
+		handleSubmit: warHandleSubmit,
+		formState: { errors: warErrors },
+	} = useForm<EditFormInputs>();
+
+	// Separate form submit handlers
+	const dynastySubmitForm: SubmitHandler<EditFormInputs> = (results) => {
+		const data = {
+			...results,
+			type: 'edit',
+			entity: 'dynasty',
+			date: new Date().toString(),
+		};
+		console.log(data);
+		// TODO: Make a request to backend to send this form details
+	};
+
+	const rulerSubmitForm: SubmitHandler<EditFormInputs> = (results) => {
+		const data = {
+			...results,
+			type: 'edit',
+			entity: 'ruler',
+			date: new Date().toString(),
+		};
+		console.log(data);
+		// TODO: Make a request to backend to send this form details
+	};
+
+	const warSubmitForm: SubmitHandler<EditFormInputs> = (results) => {
+		const data = {
+			...results,
+			type: 'edit',
+			entity: 'war',
+			date: new Date().toString(),
+		};
+		console.log(data);
+		// TODO: Make a request to backend to send this form details
+	};
+
 	return (
 		<section className="from-primary-400 to-primary-700 text-primary-70 my-6 rounded-xl bg-linear-to-br p-8 max-md:px-4">
 			<div>
-				<Tabs
-					defaultValue={tabValue}
-					value={tabValue}
-					onValueChange={changeTab}
+				<form
+					onSubmit={
+						// Dynasty
+						((tabValue === 'dynasty' &&
+							dynastyHandleSubmit(
+								dynastySubmitForm
+							)) as FormEventHandler<HTMLFormElement>) ||
+						// Ruler
+						((tabValue === 'ruler' &&
+							rulerHandleSubmit(
+								rulerSubmitForm
+							)) as FormEventHandler<HTMLFormElement>) ||
+						// War
+						((tabValue === 'war' &&
+							warHandleSubmit(
+								warSubmitForm
+							)) as FormEventHandler<HTMLFormElement>)
+					}
 				>
-					<TabsList className="w-sm max-md:w-full">
-						<TabsTrigger value="dynasty">Dynasty</TabsTrigger>
-						<TabsTrigger value="ruler">Ruler</TabsTrigger>
-						<TabsTrigger value="war">War</TabsTrigger>
-					</TabsList>
+					<Tabs
+						defaultValue={tabValue}
+						value={tabValue}
+						onValueChange={changeTab}
+					>
+						<TabsList className="w-sm max-md:w-full">
+							<TabsTrigger value="dynasty">Dynasty</TabsTrigger>
+							<TabsTrigger value="ruler">Ruler</TabsTrigger>
+							<TabsTrigger value="war">War</TabsTrigger>
+						</TabsList>
 
-					<div className="mt-2">
-						<EditDynastyTabsContent />
-						<EditRulerTabsContent />
-						<EditWarTabsContent />
-					</div>
-				</Tabs>
+						<div className="mt-2">
+							<EditDynastyTabsContent
+								register={dynastyRegister}
+								errors={dynastyErrors}
+							/>
+							<EditRulerTabsContent
+								register={rulerRegister}
+								errors={rulerErrors}
+							/>
+							<EditWarTabsContent
+								register={warRegister}
+								errors={warErrors}
+							/>
+						</div>
+					</Tabs>
 
-				<UserInfo />
-				<BasicButton
-					variant="light"
-					className="mt-6 flex w-xs items-center justify-center gap-x-1 py-3 text-center font-medium max-md:w-full"
-				>
-					<span>Submit</span>
-					<span>
-						<Send size={15} />
-					</span>
-				</BasicButton>
+					<UserInfo
+						register={
+							(tabValue === 'dynasty' ? dynastyRegister : null) ||
+							(tabValue === 'ruler' ? rulerRegister : null) ||
+							(tabValue === 'war' ? warRegister : null)
+						}
+						errors={
+							(tabValue === 'dynasty' ? dynastyErrors : null) ||
+							(tabValue === 'ruler' ? rulerErrors : null) ||
+							(tabValue === 'war' ? warErrors : null)
+						}
+					/>
+
+					<BasicButton
+						variant="light"
+						className="mt-6 flex w-xs items-center justify-center gap-x-1 py-3 text-center font-medium max-md:w-full"
+						type="submit"
+					>
+						<span>Submit</span>
+						<span>
+							<Send size={15} />
+						</span>
+					</BasicButton>
+				</form>
 			</div>
 		</section>
 	);

--- a/src/sections/issues/edit/EditDynastyTabsContent.tsx
+++ b/src/sections/issues/edit/EditDynastyTabsContent.tsx
@@ -1,9 +1,20 @@
 import InputFormControl from '@/components/issues/InputFormControl';
 import TextAreaFormControl from '@/components/issues/TextAreaFormControl';
 import { TabsContent } from '@/components/ui/tabs';
+import FormErrorLabel from '@/components/views/FormErrorLabel';
 import editDynastyFields from '@/data/issues/editDynastyFields';
+import { EditFormInputs } from '@/interfaces/EditFormInputs';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
 
-export default function EditDynastyTabsContent() {
+interface FunctionProps {
+	register: UseFormRegister<EditFormInputs>;
+	errors: FieldErrors<EditFormInputs>;
+}
+
+export default function EditDynastyTabsContent({
+	register,
+	errors,
+}: FunctionProps) {
 	return (
 		<>
 			<TabsContent value="dynasty">
@@ -20,25 +31,51 @@ export default function EditDynastyTabsContent() {
 					{editDynastyFields.map(function (field) {
 						if (field.type === 'input') {
 							return (
-								<InputFormControl
-									key={field.id}
-									id={field.htmlId}
-									label={field.label}
-									placeholder={field.placeholder}
-									required={field.required}
-									info={field.info}
-								/>
+								<>
+									<InputFormControl
+										key={field.id}
+										id={field.htmlId}
+										label={field.label}
+										required={field.required}
+										placeholder={field.placeholder}
+										info={field.info}
+										{...register(field.registerHookForm, {
+											required: {
+												value: field.required as boolean,
+												message: `${field.label} is a required field`,
+											},
+										})}
+									/>
+									{errors[field.registerHookForm] && (
+										<FormErrorLabel>
+											{errors[field.registerHookForm]?.message}
+										</FormErrorLabel>
+									)}
+								</>
 							);
 						} else if (field.type === 'textarea') {
 							return (
-								<TextAreaFormControl
-									key={field.id}
-									id={field.htmlId}
-									label={field.label}
-									placeholder={field.placeholder}
-									required={field.required}
-									info={field.info}
-								/>
+								<>
+									<TextAreaFormControl
+										key={field.id}
+										id={field.htmlId}
+										label={field.label}
+										placeholder={field.placeholder}
+										info={field.info}
+										required={field.required}
+										{...register(field.registerHookForm, {
+											required: {
+												value: field.required as boolean,
+												message: `${field.label} is a required field`,
+											},
+										})}
+									/>
+									{errors[field.registerHookForm] && (
+										<FormErrorLabel>
+											{errors[field.registerHookForm]?.message}
+										</FormErrorLabel>
+									)}
+								</>
 							);
 						}
 					})}

--- a/src/sections/issues/edit/EditRulerTabsContent.tsx
+++ b/src/sections/issues/edit/EditRulerTabsContent.tsx
@@ -1,9 +1,20 @@
 import InputFormControl from '@/components/issues/InputFormControl';
 import TextAreaFormControl from '@/components/issues/TextAreaFormControl';
 import { TabsContent } from '@/components/ui/tabs';
+import FormErrorLabel from '@/components/views/FormErrorLabel';
 import editRulerFields from '@/data/issues/editRulerFields';
+import { EditFormInputs } from '@/interfaces/EditFormInputs';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
 
-export default function EditRulerTabsContent() {
+interface FunctionProps {
+	register: UseFormRegister<EditFormInputs>;
+	errors: FieldErrors<EditFormInputs>;
+}
+
+export default function EditRulerTabsContent({
+	register,
+	errors,
+}: FunctionProps) {
 	return (
 		<>
 			<TabsContent value="ruler">
@@ -20,25 +31,51 @@ export default function EditRulerTabsContent() {
 					{editRulerFields.map(function (field) {
 						if (field.type === 'input') {
 							return (
-								<InputFormControl
-									key={field.id}
-									id={field.htmlId}
-									label={field.label}
-									placeholder={field.placeholder}
-									info={field.info}
-									required={field.required}
-								/>
+								<>
+									<InputFormControl
+										key={field.id}
+										id={field.htmlId}
+										label={field.label}
+										required={field.required}
+										placeholder={field.placeholder}
+										info={field.info}
+										{...register(field.registerHookForm, {
+											required: {
+												value: field.required as boolean,
+												message: `${field.label} is a required field`,
+											},
+										})}
+									/>
+									{errors[field.registerHookForm] && (
+										<FormErrorLabel>
+											{errors[field.registerHookForm]?.message}
+										</FormErrorLabel>
+									)}
+								</>
 							);
 						} else if (field.type === 'textarea') {
 							return (
-								<TextAreaFormControl
-									key={field.id}
-									id={field.htmlId}
-									label={field.label}
-									placeholder={field.placeholder}
-									info={field.info}
-									required={field.required}
-								/>
+								<>
+									<TextAreaFormControl
+										key={field.id}
+										id={field.htmlId}
+										label={field.label}
+										placeholder={field.placeholder}
+										info={field.info}
+										required={field.required}
+										{...register(field.registerHookForm, {
+											required: {
+												value: field.required as boolean,
+												message: `${field.label} is a required field`,
+											},
+										})}
+									/>
+									{errors[field.registerHookForm] && (
+										<FormErrorLabel>
+											{errors[field.registerHookForm]?.message}
+										</FormErrorLabel>
+									)}
+								</>
 							);
 						}
 					})}

--- a/src/sections/issues/edit/EditWarTabsContent.tsx
+++ b/src/sections/issues/edit/EditWarTabsContent.tsx
@@ -1,9 +1,20 @@
 import InputFormControl from '@/components/issues/InputFormControl';
 import TextAreaFormControl from '@/components/issues/TextAreaFormControl';
 import { TabsContent } from '@/components/ui/tabs';
+import FormErrorLabel from '@/components/views/FormErrorLabel';
 import editWarFields from '@/data/issues/editWarFields';
+import { EditFormInputs } from '@/interfaces/EditFormInputs';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
 
-export default function EditWarTabsContent() {
+interface FunctionProps {
+	register: UseFormRegister<EditFormInputs>;
+	errors: FieldErrors<EditFormInputs>;
+}
+
+export default function EditWarTabsContent({
+	register,
+	errors,
+}: FunctionProps) {
 	return (
 		<>
 			<TabsContent value="war">
@@ -20,25 +31,51 @@ export default function EditWarTabsContent() {
 					{editWarFields.map(function (field) {
 						if (field.type === 'input') {
 							return (
-								<InputFormControl
-									key={field.id}
-									id={field.htmlId}
-									label={field.label}
-									placeholder={field.placeholder}
-									info={field.info}
-									required={field.required}
-								/>
+								<>
+									<InputFormControl
+										key={field.id}
+										id={field.htmlId}
+										label={field.label}
+										required={field.required}
+										placeholder={field.placeholder}
+										info={field.info}
+										{...register(field.registerHookForm, {
+											required: {
+												value: field.required as boolean,
+												message: `${field.label} is a required field`,
+											},
+										})}
+									/>
+									{errors[field.registerHookForm] && (
+										<FormErrorLabel>
+											{errors[field.registerHookForm]?.message}
+										</FormErrorLabel>
+									)}
+								</>
 							);
 						} else if (field.type === 'textarea') {
 							return (
-								<TextAreaFormControl
-									key={field.id}
-									id={field.htmlId}
-									label={field.label}
-									placeholder={field.placeholder}
-									info={field.info}
-									required={field.required}
-								/>
+								<>
+									<TextAreaFormControl
+										key={field.id}
+										id={field.htmlId}
+										label={field.label}
+										placeholder={field.placeholder}
+										info={field.info}
+										required={field.required}
+										{...register(field.registerHookForm, {
+											required: {
+												value: field.required as boolean,
+												message: `${field.label} is a required field`,
+											},
+										})}
+									/>
+									{errors[field.registerHookForm] && (
+										<FormErrorLabel>
+											{errors[field.registerHookForm]?.message}
+										</FormErrorLabel>
+									)}
+								</>
 							);
 						}
 					})}

--- a/src/sections/issues/user/UserInfo.tsx
+++ b/src/sections/issues/user/UserInfo.tsx
@@ -1,8 +1,16 @@
 import InputFormControl from '@/components/issues/InputFormControl';
 import TextAreaFormControl from '@/components/issues/TextAreaFormControl';
+import FormErrorLabel from '@/components/views/FormErrorLabel';
 import userInfo from '@/data/issues/userInfo';
+import { EditFormInputs } from '@/interfaces/EditFormInputs';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
 
-export default function UserInfo() {
+interface FunctionProps {
+	register: UseFormRegister<EditFormInputs> | null;
+	errors: FieldErrors<EditFormInputs> | null;
+}
+
+export default function UserInfo({ register, errors }: FunctionProps) {
 	return (
 		<div className="border-primary-70/35 mt-5 border-t pt-2">
 			<h3 className="text-xl font-medium">User Info</h3>
@@ -14,27 +22,63 @@ export default function UserInfo() {
 
 			<div>
 				{userInfo.map(function (field) {
-					if (field.type === 'input') {
+					if (field.type === 'input' && register !== null && errors !== null) {
 						return (
-							<InputFormControl
-								key={field.id}
-								label={field.label}
-								placeholder={field.placeholder}
-								required={field.required}
-								id={field.htmlId}
-								info={field.info}
-							/>
+							<>
+								<InputFormControl
+									key={field.id}
+									label={field.label}
+									placeholder={field.placeholder}
+									required={field.required}
+									id={field.htmlId}
+									info={field.info}
+									{...register(field.registerHookForm, {
+										required: {
+											value: field.required as boolean,
+											message: `${field.label} is a required field`,
+										},
+										pattern: {
+											value: field.validationPattern
+												? (field.validationPattern as RegExp)
+												: /.*/,
+											message: 'Please enter a valid email address',
+										},
+									})}
+								/>
+								{errors[field.registerHookForm] && (
+									<FormErrorLabel>
+										{errors[field.registerHookForm]?.message}
+									</FormErrorLabel>
+								)}
+							</>
 						);
-					} else if (field.type === 'textarea') {
+					} else if (
+						field.type === 'textarea' &&
+						register !== null &&
+						errors !== null
+					) {
 						return (
-							<TextAreaFormControl
-								key={field.id}
-								label={field.label}
-								placeholder={field.placeholder}
-								required={field.required}
-								id={field.htmlId}
-								info={field.info}
-							/>
+							<>
+								<TextAreaFormControl
+									key={field.id}
+									label={field.label}
+									placeholder={field.placeholder}
+									required={field.required}
+									id={field.htmlId}
+									info={field.info}
+									{...register(field.registerHookForm, {
+										required: {
+											value: field.required as boolean,
+											message: `${field.label} is a required field`,
+										},
+									})}
+								/>
+								{errors[field.registerHookForm] && (
+									<FormErrorLabel>
+										{errors[field.registerHookForm]?.message}
+									</FormErrorLabel>
+								)}
+							</>
 						);
 					}
 				})}


### PR DESCRIPTION
- Create and setup `react-h00k-form` in Edit Contributions form sections for dynasties, rulers, wars and user info.
- Display label errors on unfilled/inaccurate form values.